### PR TITLE
change compress type from zip to tar.gz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.so
 *.dylib
 *.zip
+*.tar.gz
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -57,7 +57,7 @@ var scanCmd = &cobra.Command{
 		arc := archiver.New()
 
 		// setup guardrails api client
-		grclient := guardrailsclient.New(cfg.HttpClient, args.Token)
+		grclient := guardrailsclient.New(cfg, args.Token)
 
 		// setup output writer
 		outputWriter := outputwriter.New(args.Output)

--- a/internal/client/guardrails/client.go
+++ b/internal/client/guardrails/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	httpClient "github.com/guardrailsio/guardrails-cli/internal/client"
@@ -28,19 +29,19 @@ type GuardRailsClient interface {
 }
 
 type client struct {
-	cfg        *config.HttpClientConfig
+	cfg        *config.Config
 	httpclient *http.Client
 	token      string
 }
 
 // New instantiates new GuardRailsClient.
-func New(cfg *config.HttpClientConfig, token string) GuardRailsClient {
+func New(cfg *config.Config, token string) GuardRailsClient {
 	return &client{cfg: cfg, httpclient: new(http.Client), token: token}
 }
 
 // CreateUploadURL implements guardrailsclient.GuardRailsClient interface.
 func (c *client) CreateUploadURL(ctx context.Context, req *CreateUploadURLReq) (*CreateUploadURLResp, error) {
-	url := "https://API.guardrails.io/v2/cli/trigger-zip-scan-upload-url"
+	url := fmt.Sprintf("%s/v2/cli/trigger-zip-scan-upload-url", c.cfg.GuardRailsClient.APIHost)
 
 	req.CLIToken = c.token
 	reqBody, err := json.Marshal(req)
@@ -48,7 +49,7 @@ func (c *client) CreateUploadURL(ctx context.Context, req *CreateUploadURLReq) (
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.HttpClient.Timeout)
 	defer cancel()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
@@ -98,7 +99,7 @@ func (c *client) UploadProject(ctx context.Context, req *UploadProjectReq) error
 
 // TriggerScan implements guardrailsclient.GuardRailsClient interface.
 func (c *client) TriggerScan(ctx context.Context, req *TriggerScanReq) (*TriggerScanResp, error) {
-	url := "https://api.guardrails.io/v2/cli/trigger-zip-scan"
+	url := fmt.Sprintf("%s/v2/cli/trigger-zip-scan", c.cfg.GuardRailsClient.APIHost)
 
 	req.CLIToken = c.token
 	reqBody, err := json.Marshal(req)
@@ -106,7 +107,7 @@ func (c *client) TriggerScan(ctx context.Context, req *TriggerScanReq) (*Trigger
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.HttpClient.Timeout)
 	defer cancel()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
@@ -135,9 +136,9 @@ func (c *client) TriggerScan(ctx context.Context, req *TriggerScanReq) (*Trigger
 
 // GetScanData implements guardrailsclient.GuardRailsClient interface.
 func (c *client) GetScanData(ctx context.Context, req *GetScanDataReq) (*GetScanDataResp, error) {
-	url := "https://api.guardrails.io/v2/cli/scan"
+	url := fmt.Sprintf("%s/v2/cli/scan", c.cfg.GuardRailsClient.APIHost)
 
-	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.HttpClient.Timeout)
 	defer cancel()
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/internal/command/scan/format/pretty.go
+++ b/internal/command/scan/format/pretty.go
@@ -14,7 +14,12 @@ func GetScanDataPrettyFormat(w io.Writer, resp *guardrailsclient.GetScanDataResp
 	if resp.OK {
 		fmt.Fprintf(w, "%s\n", prettyFmt.Success("No issues detected, well done!"))
 	} else {
-		fmt.Fprintf(w, "%s\n", prettyFmt.Warning(fmt.Sprintf("We detected %d security issue", resp.Results.Count.Total)))
+		issueStr := "issue"
+		if resp.Results.Count.Total > 1 {
+			issueStr += "s"
+		}
+
+		fmt.Fprintf(w, "%s\n", prettyFmt.Warning(fmt.Sprintf("We detected %d security %s", resp.Results.Count.Total, issueStr)))
 
 		for _, r := range resp.Results.Rules {
 			fmt.Fprintf(w, "%s (%d)\n", r.Rule.Title, r.Count.Total)

--- a/internal/command/scan/handler.go
+++ b/internal/command/scan/handler.go
@@ -94,7 +94,7 @@ func (h *Handler) Execute(ctx context.Context) error {
 	h.stopLoadingMessage()
 
 	// create presigned url for uploading the compressed file
-	projectZipName := fmt.Sprintf("%s.zip", repoMetadata.Name)
+	projectZipName := fmt.Sprintf("%s_%s.tar.gz", repoMetadata.Name, repoMetadata.CommitHash)
 	createUploadURLReq := &grclient.CreateUploadURLReq{
 		File: projectZipName,
 	}

--- a/internal/command/scan/handler_test.go
+++ b/internal/command/scan/handler_test.go
@@ -92,7 +92,7 @@ func TestScanCommandExecuteSuccess(t *testing.T) {
 		"internal/tools/spinner/spinner.go",
 		"main.go",
 	}
-	fileZipName := fmt.Sprintf("%s.zip", repoMetadata.Name)
+	fileZipName := fmt.Sprintf("%s_%s.tar.gz", repoMetadata.Name, repoMetadata.CommitHash)
 	fileZipByte := bytes.NewReader([]byte{})
 	createUploadURLReq := &grclient.CreateUploadURLReq{
 		File: fileZipName,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,12 @@ package config
 
 import "time"
 
+// Config provides centralized configuration for the application.
+type Config struct {
+	HttpClient       *HttpClientConfig
+	GuardRailsClient *GuardRailsClient
+}
+
 // New instantiates new config.
 func New() *Config {
 	return &Config{
@@ -10,12 +16,8 @@ func New() *Config {
 			Timeout:         2 * time.Second,
 			RetryTimeout:    30 * time.Minute,
 		},
+		GuardRailsClient: NewGuardRailsClientConfig(),
 	}
-}
-
-// Config provides centralized configuration for the application.
-type Config struct {
-	HttpClient *HttpClientConfig
 }
 
 // HttpClientConfig provides configuration for guardrails cli http client.

--- a/internal/config/guardrailsclient.go
+++ b/internal/config/guardrailsclient.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"errors"
+	"os"
+)
+
+var (
+	ErrMissingGuardRailsAPIHost = errors.New("missing mandatory GUARDRAILS_API_HOST environment variables.")
+)
+
+// GuardRailsClient contains configuration for guardrails client.
+type GuardRailsClient struct {
+	APIHost string
+}
+
+func NewGuardRailsClientConfig() *GuardRailsClient {
+	apiHost := os.Getenv("GUARDRAILS_API_HOST")
+	if apiHost == "" {
+		apiHost = "https://api.guardrails.io"
+	}
+
+	return &GuardRailsClient{APIHost: apiHost}
+}

--- a/internal/format/pretty/pretty.go
+++ b/internal/format/pretty/pretty.go
@@ -13,7 +13,7 @@ func Error(err error) error {
 		return nil
 	}
 
-	return fmt.Errorf("%s Error: %s", emoji.Warning, text.FgYellow.Sprint(err.Error()))
+	return fmt.Errorf(text.FgYellow.Sprintf("%s  Error: %s", emoji.Warning, err.Error()))
 }
 
 // Warning returns pretty formatted warning message.


### PR DESCRIPTION
- [x] pointing the CLI to our staging environment for now instead of production (for all API calls). The domain is https://api.staging.k8s.guardrails.io instead of https://api.guardrails.io
- [x] the archive name should be unique to prevent overwriting, so we should use {project name}_{commit SHA}.zip instead, I’ve updated the requirements doc
- [x] the node code which is extracting (using zlib) the archive triggers an `incorrect header check error`

https://www.loom.com/share/47faed502b354913bf7d6376c194d3e0