### PR TITLE
address performance improvement feedback from GuardRails team

### DIFF
--- a/internal/client/guardrails/message.go
+++ b/internal/client/guardrails/message.go
@@ -95,7 +95,7 @@ type GetScanDataRuleResp struct {
 		Name   string `json:"name"`
 		Docs   string `json:"docs"`
 	} `json:"rule"`
-	Languages       []string                         `json:"languages"`
+	Languages       []string                         `json:"language"`
 	Count           *GetScanDataCountResp            `json:"count"`
 	Vulnerabilities []GetScanDataVulnerabilitiesResp `json:"vulnerabilities"`
 }

--- a/internal/command/scan/args.go
+++ b/internal/command/scan/args.go
@@ -17,7 +17,8 @@ const (
 )
 
 var (
-	ErrMissingToken = errors.New("missing token, please provide your Guardrails CLI token via -—token option or GUARDRAILS_CLI_TOKEN environment variable")
+	ErrMissingToken       = errors.New("missing token, please provide your Guardrails CLI token via -—token option or GUARDRAILS_CLI_TOKEN environment variable")
+	ErrInvalidFormatParam = errors.New("failed to parse format value")
 )
 
 // Args provides arguments for scan command handler.
@@ -49,7 +50,7 @@ func (args *Args) SetDefault() error {
 func isFormatAllowed(value interface{}) error {
 	input, ok := value.(string)
 	if !ok {
-		return errors.New("failed to parse format value")
+		return ErrInvalidFormatParam
 	}
 
 	allowedFormat := []string{FormatJSON, FormatCSV, FormatSARIF, FormatPretty}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -17,6 +17,7 @@ var (
 	ErrNotAValidGitRepo = func(path string) error {
 		return fmt.Errorf("%s is not a valid git repository", path)
 	}
+	ErrGitRemoteURLNotFound = errors.New("repository doesn't have remote URLs")
 )
 
 //go:generate mockgen -destination=mock/repository.go -package=mockrepository . Repository
@@ -71,7 +72,7 @@ func (r *repository) GetMetadataFromRemoteURL() (*Metadata, error) {
 	// TODO: currently we only take first remote URL from origin. It could be expanded later since git can have multiple remote urls.
 	remoteURLs := cfg.Remotes["origin"].URLs
 	if len(remoteURLs) == 0 {
-		return nil, errors.New("repository doesn't have remote URLs")
+		return nil, ErrGitRemoteURLNotFound
 	}
 
 	remoteURL := remoteURLs[0]


### PR DESCRIPTION
This PR address feedback from GuardRails team regarding performance improvements as suggested below

- [X] All static errors should be global const errors - Should not return a new error object on Heap. This is to avoid GC on dynamic error objects, then help to improve performance.
```
func isFormatAllowed(value interface{}) error {
  input, ok := value.(string)
  if !ok {
   // Should not return a error object on Heap 
   return errors.New("failed to parse format value")
  }
  ...
}
```

- [X] Avoid using defer function in a for loop to avoid stack/heap memory usage increasing a lot. For example, with below codes, if we have a big folder with a lot of files, then Go app will keep opened a lot of files during the for loop, and will not close these files until the end of function.
````
func compress(projectPath string, filepaths []string, output io.Writer) (err error) {
    ...
    for _, path := range filepaths {
      ...
      // Should not use defer function in a loop 
      defer func() {
        closeErr := file.Close()
        if err == nil {
          err = closeErr
        }
      }()
    }
    ...
 }
````
