### PR TITLE
change CVSS score type from int to float

### DIFF
--- a/internal/client/guardrails/message.go
+++ b/internal/client/guardrails/message.go
@@ -130,7 +130,7 @@ type GetScanDataVulnerabilitiesResp struct {
 		Docs         string `json:"docs"`
 		EngineName   string `json:"engineName"`
 		CvssSeverity string `json:"cvssSeverity"`
-		CvssScore    int64  `json:"cvssScore"`
+		CvssScore    float64`json:"cvssScore"`
 		CvssVector   string `json:"cvssVector"`
 	} `json:"engineRule"`
 }


### PR DESCRIPTION
The CVSS score on engine rules can in some cases be a decimal number (see screenshot).

Not sure if there is a better type in golang for representing decimal values than using float, if there is then please let me know.
![image](https://user-images.githubusercontent.com/62658460/197719801-53412fa6-f71a-496d-96a6-f4ff977f862d.png)
