### PR TITLE
parse git urls where the hostname doesn't contain a domain name

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -77,7 +77,7 @@ func (r *repository) GetMetadataFromRemoteURL() (*Metadata, error) {
 
 	remoteURL := remoteURLs[0]
 
-	re := regexp.MustCompile(`(?P<Protocol>git@|http(s)?:\/\/)(.+@)*(?P<Provider>[\w\d\.-]+)(:[\d]+){0,1}\/*(?P<Name>.*)`)
+	re := regexp.MustCompile(`(?P<Protocol>git@|http(s)?:\/\/)(.+@)*(?P<Provider>[\w\d\.]+)(:[\d]+){0,1}\/*(?P<Name>.*)`)
 	matches := re.FindStringSubmatch(remoteURL)
 
 	protocolRe := regexp.MustCompile(`[^\w]`)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -77,13 +77,13 @@ func (r *repository) GetMetadataFromRemoteURL() (*Metadata, error) {
 
 	remoteURL := remoteURLs[0]
 
-	re := regexp.MustCompile(`(?P<Protocol>git@|http(s)?:\/\/)(.+@)*(?P<Provider>[\w\d\.]+)(:[\d]+){0,1}\/*(?P<Name>.*)`)
+	re := regexp.MustCompile(`(?P<Protocol>git@|http(s)?:\/\/)(.+@)*(?P<Provider>[\w\d\.-]+)(:[\d]+){0,1}\/*(?P<Name>.*)`)
 	matches := re.FindStringSubmatch(remoteURL)
 
 	protocolRe := regexp.MustCompile(`[^\w]`)
 	protocol := protocolRe.ReplaceAllString(matches[re.SubexpIndex("Protocol")], "")
 
-	providerRe := regexp.MustCompile(`^(.*?)\.`)
+	providerRe := regexp.MustCompile(`^([\w\d-]+)([\.\w\d]*)`)
 	provider := providerRe.FindStringSubmatch(matches[re.SubexpIndex("Provider")])
 
 	nameRe := regexp.MustCompile(`\/(.*)\.git$`)


### PR DESCRIPTION
This is an edge case and likely won't show up in a real deployment. But in the functional tests the hostname of the Gitlab enterprise server is `gitlab-ee` (without any domain name). This causes the regexp to not match because the regexp assumes that there should be a domain name.

Here's a screenshot of how the Git config looks like in the functional tests.
![image](https://user-images.githubusercontent.com/62658460/197726021-e378ff9a-1f3f-4564-94b7-cf693507ef8f.png)
