### PR TITLE
parse git urls where the hostname contains a hyphen character

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -77,7 +77,7 @@ func (r *repository) GetMetadataFromRemoteURL() (*Metadata, error) {
 
 	remoteURL := remoteURLs[0]
 
-	re := regexp.MustCompile(`(?P<Protocol>git@|http(s)?:\/\/)(.+@)*(?P<Provider>[\w\d\.]+)(:[\d]+){0,1}\/*(?P<Name>.*)`)
+	re := regexp.MustCompile(`(?P<Protocol>git@|http(s)?:\/\/)(.+@)*(?P<Provider>[\w\d\.-]+)(:[\d]+){0,1}\/*(?P<Name>.*)`)
 	matches := re.FindStringSubmatch(remoteURL)
 
 	protocolRe := regexp.MustCompile(`[^\w]`)


### PR DESCRIPTION
The regexp doesn't match if the hostname contains a hyphen character, for example `https://gitlab-on-premise.com/test-account/test-repository.git`. This is an issue in the functional tests where the hostname of the Gitlab enterprise server is `gitlab-ee`.