### PR TITLE
parse git urls for Bitbucket DC

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -77,7 +77,7 @@ func (r *repository) GetMetadataFromRemoteURL() (*Metadata, error) {
 
 	remoteURL := remoteURLs[0]
 
-	re := regexp.MustCompile(`(?P<Protocol>git@|http(s)?:\/\/)(.+@)*(?P<Provider>[\w\d\.]+)(:[\d]+){0,1}\/*(?P<Name>.*)`)
+	re := regexp.MustCompile(`(?P<Protocol>git@|http(s)?:\/\/)(.+@)*(?P<Provider>[\w\d\.]+)(:[\d]+){0,1}(\/scm)?\/*(?P<Name>.*)`)
 	matches := re.FindStringSubmatch(remoteURL)
 
 	protocolRe := regexp.MustCompile(`[^\w]`)


### PR DESCRIPTION
For Bitbucket Data Center the path of the URL is prefixed with `scm` in the GIT URL. Example: `http://test-user:test-password@bitbucket-server:7990/scm/test-account/test-repo.git`. This PR is for adding `scm` to the GIT URL regex.