### PR TITLE
add url parser and test for git remote url parser

### DIFF
--- a/internal/command/scan/handler_test.go
+++ b/internal/command/scan/handler_test.go
@@ -51,10 +51,10 @@ func TestScanCommandExecuteSuccess(t *testing.T) {
 	commitHash := fmt.Sprintf("%x", encrypted)
 
 	repoMetadata := &repository.Metadata{
-		Path:       args.Path,
+		DirPath:    args.Path,
 		Protocol:   "https",
 		Provider:   "github",
-		Name:       gofakeit.AppName(),
+		RepoName:   gofakeit.AppName(),
 		Branch:     gofakeit.Word(),
 		CommitHash: commitHash,
 	}
@@ -92,7 +92,7 @@ func TestScanCommandExecuteSuccess(t *testing.T) {
 		"internal/tools/spinner/spinner.go",
 		"main.go",
 	}
-	fileZipName := fmt.Sprintf("%s_%s.tar.gz", repoMetadata.Name, repoMetadata.CommitHash)
+	fileZipName := fmt.Sprintf("%s_%s.tar.gz", repoMetadata.RepoName, repoMetadata.CommitHash)
 	fileZipByte := bytes.NewReader([]byte{})
 	createUploadURLReq := &grclient.CreateUploadURLReq{
 		File: fileZipName,
@@ -105,7 +105,7 @@ func TestScanCommandExecuteSuccess(t *testing.T) {
 		File:      fileZipByte,
 	}
 	triggerScanReq := &grclient.TriggerScanReq{
-		Repository: repoMetadata.Name,
+		Repository: repoMetadata.RepoName,
 		SHA:        repoMetadata.CommitHash,
 		Branch:     repoMetadata.Branch,
 		FileName:   fileZipName,
@@ -129,7 +129,7 @@ func TestScanCommandExecuteSuccess(t *testing.T) {
 	gomock.InOrder(
 		mockRepo.EXPECT().GetMetadataFromRemoteURL().Return(repoMetadata, nil),
 		mockRepo.EXPECT().ListFiles().Return(listOfFiles, nil),
-		mockArc.EXPECT().OutputZipToIOReader(repoMetadata.Path, listOfFiles).Return(fileZipByte, nil),
+		mockArc.EXPECT().OutputZipToIOReader(repoMetadata.DirPath, listOfFiles).Return(fileZipByte, nil),
 		mockGrClient.EXPECT().CreateUploadURL(ctx, createUploadURLReq).Return(createUploadURLResp, nil),
 		mockGrClient.EXPECT().UploadProject(ctx, uploadProjectReq).Return(nil),
 		mockGrClient.EXPECT().TriggerScan(ctx, triggerScanReq).Return(triggerScanResp, nil),

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -1,0 +1,34 @@
+package repository
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseGitRemoteURLToMetadataSuccess(t *testing.T) {
+	userAccount := gofakeit.Username()
+	repoName := fmt.Sprintf("%s-%s", gofakeit.LoremIpsumWord(), gofakeit.LoremIpsumWord())
+
+	urls := []string{
+		fmt.Sprintf("git@github.com:%s/%s.git", userAccount, repoName),
+		fmt.Sprintf("http://github.com/%s/%s.git", userAccount, repoName),
+		fmt.Sprintf("https://github.com/%s/%s.git", userAccount, repoName),
+		fmt.Sprintf("http://username:password@bitbucket-server:7990/scm/%s/%s.git", userAccount, repoName),
+		fmt.Sprintf("https://gitlab-on-premise.com/%s/%s.git", userAccount, repoName),
+		fmt.Sprintf("http://username:password@gitlab-ee/scm/%s/%s.git", userAccount, repoName),
+		fmt.Sprintf("https://username:password@sub-domain-1.sub-domain-2.host.xz/prefix1/prefix2/prefix3/%s/%s.git", userAccount, repoName),
+	}
+
+	metadata := new(Metadata)
+
+	for _, url := range urls {
+		getMetadataFromRemoteURL(metadata, url)
+		assert.NotEmpty(t, metadata.Protocol)
+		assert.NotEmpty(t, metadata.Provider)
+		assert.Equal(t, metadata.UserAccount, userAccount)
+		assert.Equal(t, metadata.RepoName, repoName)
+	}
+}


### PR DESCRIPTION
- Add more information to repository metadata struct (RemoteURL, UserAccount)
```
type Metadata struct {
	DirPath     string
	Protocol    string
	Provider    string
	UserAccount string
	RemoteURL   string
	RepoName    string
	Branch      string
	CommitHash  string
}
```
- Implement method to extract user account and repo name by splitting git remote URL as suggested by @HenrikAlexisNilsson 
- Add test and sample git remote URL for git remote URL parser 